### PR TITLE
bug in video detection

### DIFF
--- a/examples/MTSrc/MTMain.cpp
+++ b/examples/MTSrc/MTMain.cpp
@@ -574,7 +574,11 @@ void MTCNN::Detect(const cv::Mat& image,std::vector<FaceInfo>& faceInfo,int minS
       regressed_rects_ = BoxRegress(condidate_rects_,3);
       faceInfo = NonMaximumSuppression(regressed_rects_,0.7,'m');
     }
+    else
+      faceInfo.clear();
   }
+  else
+    faceInfo.clear();
   regressed_pading_.clear();
   regressed_rects_.clear();
   condidate_rects_.clear();


### PR DESCRIPTION
when a person go out of the frame,the faceInfo was not clear. then will display a  face rectangle in the frame without face. 